### PR TITLE
Override the variable display-buffer-overriding-action

### DIFF
--- a/current-window-only.el
+++ b/current-window-only.el
@@ -54,6 +54,7 @@
 ;; we want to set the variables to their previous values instead of the
 ;; default ones.
 (defvar current-window-only--old-config '())
+(defvar Man-notify-method)
 
 ;;;; Functions
 
@@ -61,14 +62,18 @@
 
 (defun current-window-only--on ()
   ;; Remember the user configuration in case we need to restore it
-  (dolist (var '(display-buffer-overriding-action))
+  (dolist (var '(display-buffer-overriding-action
+		 Man-notify-method))
     (when (boundp var)
       (setf (alist-get var current-window-only--old-config)
             (symbol-value var))))
 
   (setq display-buffer-overriding-action
         '((display-buffer-reuse-window
-           display-buffer-same-window)))
+	   display-buffer-same-window)))
+
+  ;; Some packages require a custom configuration just for them
+  (setq Man-notify-method 'pushy)
 
   ;; The `org-agenda', `org-capture', and probably all commands with the
   ;; similar input field that expects one character and blocks all other input,

--- a/current-window-only.el
+++ b/current-window-only.el
@@ -49,12 +49,6 @@
 
 ;;;; Variables
 
-;; Some modes and packages need to be explicitly said how to behave.
-;; This is the list of variables that this package is going to modify.
-(defvar Man-notify-method)
-(defvar org-src-window-setup)
-(defvar org-agenda-window-setup)
-
 ;; We want to rember the variable values that user had before activating the
 ;; `current-window-only-mode' in case he decides to disable it. In that case
 ;; we want to set the variables to their previous values instead of the
@@ -67,25 +61,14 @@
 
 (defun current-window-only--on ()
   ;; Remember the user configuration in case we need to restore it
-  (dolist (var '(display-buffer-alist
-                 Man-notify-method
-                 org-src-window-setup
-                 org-agenda-window-setup))
+  (dolist (var '(display-buffer-overriding-action))
     (when (boundp var)
       (setf (alist-get var current-window-only--old-config)
             (symbol-value var))))
 
-  ;; The `display-buffer-alist' is still a magic to me but in the ideal world
-  ;; this should be the only necessary setting.
-  (setq display-buffer-alist
-        '((".*" (display-buffer-reuse-window
-                 display-buffer-same-window)
-           (reusable-frames . t))))
-
-  ;; Some packages require a custom configuration just for them
-  (setq Man-notify-method 'pushy)
-  (setq org-src-window-setup 'current-window)
-  (setq org-agenda-window-setup 'current-window)
+  (setq display-buffer-overriding-action
+        '((display-buffer-reuse-window
+           display-buffer-same-window)))
 
   ;; The `org-agenda', `org-capture', and probably all commands with the
   ;; similar input field that expects one character and blocks all other input,


### PR DESCRIPTION
Some functions, like `pop-to-buffer-same-window` pass an action that inhibits the appearance of new buffers in the same window. In such cases, buffers will silently fail to appear. An example of such a function that uses `pop-to-buffer-same-window` internally is the `scratch-buffer` interactive function. 

Enabling `current-window-only-mode` and running said function will cause Emacs to hang indefinitely. Due to the design of the buffer display framework, `display-buffer-overriding-action` is the most prioritized of all variables. Despite the  documentation's warnings not to ever set this variable in Lisp programs, there is really no way (that I know of) to avoid this problem without overriding it.

> This doesn't break Magit's ability to open windows side by side, **further testing should be done** to determine whether this impedes other functionality.

EDIT: I *couldn't reproduce* this issue in a clean environment, I should probably investigate whatever package is causing this odd behavior to occur.